### PR TITLE
Fixed null id in Shibboleth::authenticate for existing users 

### DIFF
--- a/Shibboleth.class.php
+++ b/Shibboleth.class.php
@@ -30,6 +30,13 @@ class Shibboleth extends PluggableAuth {
             $this->checkGroupMap();
         }
 
+        $user = User::newFromName( $username );
+        $mId = $user->getId();
+
+        if ($mId !== 0) {
+            $id = $mId;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
**The problem**
For existing users, `Shibboleth::authenticate` is passing a `null` user id, which prevents the execution of the `PluggableAuthPopulateGroup` Hook in `PluggableAuthLogin::execute` (new users are not affected).

**The fix**
Add a lookup for existing users in `Shibboleth::authenticate` using the `$username` as search key. If the user exists the user id is populated with the correct value, otherwise it is left unchanged.  
