### PR TITLE
Add option to manage users without group attribute/value

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Recommended MediaWiki version: **1.29+**
 
 ## Required packages and settings
 
-In order to use Shibboleth Apache module as an authentication method in your wiki, you need have a functional Shibboleth Service Provider (SP).
+In order to use Shibboleth Apache module as an authentication method in your wiki, you need a working Shibboleth Service Provider (SP).
 
 Install Shibboleth Apache modul on Debian/Ubuntu linux:
 
@@ -71,9 +71,11 @@ In addition, the following optional configuration variable is provided:
 Flag | Default | Description
 ---- | ------- | -----------
 $wgShibboleth_GroupMap | null | Mapping from SAML attributes to MediaWiki groups of the form: `$wgShibboleth_GroupMap = array('attr_name' => 'groups','sysop' => 'wiki_admin','bureaucrat' => 'wiki_editor', '...');` No group mapping is performed if $wgSimpleSAMLphp_GroupMap is null.
-$wgShibboleth_RequireGroup | true | Weather missing group information whould invalidate the session or not. Set to `false` to let in users without any group information.
+$wgShibboleth_RequireGroup | true | Weather missing the group SAML attribute, the `attr_name` in the `$wgShibboleth_GroupMap` , will invalidate the session or not. Set to `false` to let in users without any group mapping, in that case users will be mapped to the default unprivileged MediaWiki groups.
 
 ### Group mapping
+
+**IMPORTANT** The extentsion supports only the `sysop` and `bureaucrat` groups.
 
 Use case: your SAML IdP reads groups from LDAP or Database and stores this information inside an attribute of the SAML response. You want to use this to map MediaWiki groups to users belonging to some known groups given by your IdP.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ In addition, the following optional configuration variable is provided:
 Flag | Default | Description
 ---- | ------- | -----------
 $wgShibboleth_GroupMap | null | Mapping from SAML attributes to MediaWiki groups of the form: `$wgShibboleth_GroupMap = array('attr_name' => 'groups','sysop' => 'wiki_admin','bureaucrat' => 'wiki_editor', '...');` No group mapping is performed if $wgSimpleSAMLphp_GroupMap is null.
+$wgShibboleth_RequireGroup | true | Weather missing group information whould invalidate the session or not. Set to `false` to let in users without any group information.
 
 ### Group mapping
 

--- a/Shibboleth.class.php
+++ b/Shibboleth.class.php
@@ -172,7 +172,7 @@ class Shibboleth extends PluggableAuth {
 
     private function checkGroupMap($require_group=true) {
 	
-	if (isset($GLOBALS['wgShibboleth_RequireGroup')) {
+	if (isset($GLOBALS['wgShibboleth_RequireGroup'])) {
 	    $require_group = $GLOBALS['wgShibboleth_RequireGroup'];
 	}
 

--- a/Shibboleth.class.php
+++ b/Shibboleth.class.php
@@ -170,17 +170,22 @@ class Shibboleth extends PluggableAuth {
         }
     }
 
-    private function checkGroupMap() {
+    private function checkGroupMap($require_group=true) {
+	
+	if (isset($GLOBALS['wgShibboleth_RequireGroup')) {
+	    $require_group = $GLOBALS['wgShibboleth_RequireGroup'];
+	}
 
         $attr_name = $GLOBALS['wgShibboleth_GroupMap']['attr_name'];
 
-        if (empty($attr_name)) {
+        if (empty($attr_name) and $require_group) {
             throw new Exception(wfMessage('wg-empty-groupmap-attr')->plain());
         }
 
         $groups = filter_input(INPUT_SERVER, $attr_name);
+	
 
-        if (empty($groups)) {
+        if (empty($groups) and $require_group) {
             throw new Exception(wfMessage('shib-attr-empty-groupmap-attr')->plain());
         }
 
@@ -195,7 +200,7 @@ class Shibboleth extends PluggableAuth {
         if (empty($base_url)) {
             throw new Exception(wfMessage('shib-attr-empty-logout-base-url')->plain());
         }
-
+$
         $target_url = $GLOBALS['wgShibboleth_Logout_Target_Url'];
 
         if (empty($target_url)) {

--- a/Shibboleth.class.php
+++ b/Shibboleth.class.php
@@ -30,6 +30,13 @@ class Shibboleth extends PluggableAuth {
             $this->checkGroupMap();
         }
 
+        $user = User::newFromName( $username );
+        $mId = $user->getId();
+
+        if ($mId !== 0) {
+            $id = $mId;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
**PROBLEM**
Currently the extension throws an exception when a user without the SAML group attribute (`attr_name`) try to access the MediaWiki instance. 

**SOLUTION**
Added an option (`$wgShibboleth_RequireGroup`) to let in users without the SAML group attribute, those users will be mapped to the default MediaWiki unprivileged role.

**ADDITIONAL INFORMATION**
The PR also updates the README with both the new option and clarifying that the extension cannot be used to map groups other than the _sysop_ and the _bureaucrat_ ones.    
